### PR TITLE
enable using friendly names by default

### DIFF
--- a/lib/service_discovery.dart
+++ b/lib/service_discovery.dart
@@ -1,3 +1,5 @@
+import 'dart:convert' show utf8;
+import 'dart:typed_data';
 import 'package:flutter_mdns_plugin/flutter_mdns_plugin.dart';
 import 'package:observable/observable.dart';
 
@@ -15,6 +17,10 @@ class ServiceDiscovery extends ChangeNotifier {
             onResolved: (ServiceInfo serviceInfo) {
               // prevent duplicates
               print('found device ${serviceInfo.toString()}');
+              if (null != serviceInfo.attr && null != serviceInfo.attr['fn']) {
+                Uint8List l = Uint8List.fromList(serviceInfo.attr['fn']);
+                serviceInfo.name = utf8.decode(l);
+              }
               foundServices.add(serviceInfo);
               notifyChange();
             }


### PR DESCRIPTION
By default the example does not show the friendly names for devices (due to a bug in dart_chromecast\lib\casting\cast_device.dart). This allows friendly names to be displayed.